### PR TITLE
Removing cross-ui marshmallow class names 

### DIFF
--- a/oarepo_model_builder/datatypes/containers.py
+++ b/oarepo_model_builder/datatypes/containers.py
@@ -27,7 +27,8 @@ class ObjectDataType(DataType):
     def marshmallow(self, **extras):
         marshmallow_definition = super().marshmallow(**extras)
         self._extend_marshmallow(
-            marshmallow_definition, record_schema_class=self.model.record_schema_class
+            marshmallow_definition,
+            record_schema_class=self.model.record_schema_class,
         )
         return marshmallow_definition
 
@@ -41,7 +42,10 @@ class ObjectDataType(DataType):
         return marshmallow_definition
 
     def _extend_marshmallow(
-        self, marshmallow_definition, record_schema_class=None, suffix="Schema"
+        self,
+        marshmallow_definition,
+        record_schema_class=None,
+        suffix="Schema",
     ):
         schema_class = marshmallow_definition.get("schema-class", None)
         if not schema_class:
@@ -55,11 +59,17 @@ class ObjectDataType(DataType):
 
         schema_class = self._get_class_name(package_name, schema_class)
 
-        fingerprint = sha256(
-            json.dumps(
-                self.definition, sort_keys=True, default=lambda x: repr(x)
-            ).encode("utf-8")
-        ).hexdigest()
+        # add suffix to fingerprint so that ui and normal marshmallow classes
+        # are separate even though they share the same definition
+        fingerprint = (
+            suffix
+            + "-"
+            + sha256(
+                json.dumps(
+                    self.definition, sort_keys=True, default=lambda x: repr(x)
+                ).encode("utf-8")
+            ).hexdigest()
+        )
 
         if "known-classes" not in self.model:
             self.model.known_classes = {}

--- a/oarepo_model_builder/datatypes/datatypes.py
+++ b/oarepo_model_builder/datatypes/datatypes.py
@@ -58,6 +58,11 @@ class DataType:
             ret = copy.deepcopy(ui.get("marshmallow", {}))
         else:
             ret = copy.deepcopy(self.definition.get("marshmallow", {}))
+            # do not reuse schema class for UI (it would be in a bad package, name clash, ...)
+            schema_class = ret.pop("schema-class", None)
+            if schema_class:
+                # keep the previous name in a different package
+                ret["schema-class"] = schema_class.split(".")[-1] + "UISchema"
         if self.ui_marshmallow_field:
             ret.setdefault("field-class", self.ui_marshmallow_field)
         elif self.marshmallow_field:

--- a/oarepo_model_builder/invenio/invenio_record_schema.py
+++ b/oarepo_model_builder/invenio/invenio_record_schema.py
@@ -289,6 +289,7 @@ class InvenioRecordSchemaBuilder(InvenioBaseClassPythonBuilder):
 
     def begin(self, schema, settings):
         super().begin(schema, settings)
+
         stack = ModelBuilderStack()
         stack.push("model", schema.current_model)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-model-builder
-version = 3.2.32
+version = 3.2.33
 description = A utility library that generates OARepo required data model files from a JSON specification file
 authors = Miroslav Bauer <bauer@cesnet.cz>, Miroslav Simek <simeki@vscht.cz>
 readme = README.md

--- a/tests/test_marshmallow_ui_builder.py
+++ b/tests/test_marshmallow_ui_builder.py
@@ -29,6 +29,7 @@ from oarepo_model_builder.schema import ModelSchema
 
 OAREPO_MARSHMALLOW = "marshmallow"
 B_SCHEMA = 'classB(ma.Schema):"""Bschema."""b=ma_fields.String()'
+BUI_SCHEMA = 'classBUISchema(ma.Schema):"""BUISchemaschema."""b=ma_fields.String()'
 
 
 def get_test_schema(**props):
@@ -141,8 +142,8 @@ def test_generate_nested_schema_same_file(fulltext_builder):
         re.sub(
             r"\s",
             "",
-            """class B(ma.Schema):
-        \"""B schema.\"""
+            """class BUISchema(ma.Schema):
+        \"""BUISchema schema.\"""
         
         b = ma_fields.String()""",
         )
@@ -155,7 +156,7 @@ def test_generate_nested_schema_same_file(fulltext_builder):
             """class TestUISchema(ma.Schema):
         \"""TestUISchema schema.\"""
         
-        a = ma_fields.Nested(lambda: B())""",
+        a = ma_fields.Nested(lambda: BUISchema())""",
         )
         in re.sub(r"\s", "", data)
     )
@@ -191,18 +192,10 @@ def test_generate_nested_schema_different_file(fulltext_builder):
             """class TestUISchema(ma.Schema):
         \"""TestUISchema schema.\"""
     
-        a = ma_fields.Nested(lambda: B())""",
+        a = ma_fields.Nested(lambda: BUISchema())""",
         )
         in re.sub(r"\s", "", data)
     )
-
-    assert "from test.services.schema2 import B" in data
-
-    with fulltext_builder.filesystem.open(
-        os.path.join("test", "services", "schema2.py")  # NOSONAR
-    ) as f:
-        data = f.read()
-    assert B_SCHEMA in re.sub(r"\s", "", data)
 
 
 def test_use_nested_schema_same_file(fulltext_builder):
@@ -232,11 +225,11 @@ def test_use_nested_schema_same_file(fulltext_builder):
             """class TestUISchema(ma.Schema):
         \"""TestUISchema schema.\"""
         
-        a = ma_fields.Nested(lambda: B())""",
+        a = ma_fields.Nested(lambda: BUISchema())""",
         )
         in re.sub(r"\s", "", data)
     )
-    assert "classB(ma.Schema)" not in re.sub(r"\s", "", data)
+    assert "classBUISchema(ma.Schema)" not in re.sub(r"\s", "", data)
 
 
 def test_use_nested_schema_different_file(fulltext_builder):
@@ -258,9 +251,10 @@ def test_use_nested_schema_different_file(fulltext_builder):
         os.path.join("test", "services", "records", "ui_schema.py")
     ) as f:
         data = f.read()
-    assert re.sub(r"\s", "", "from c import B") in re.sub(r"\s", "", data)
+    # BUISchema will be undefined, definitely not in this schema
+    assert re.sub(r"\s", "", "from c import BUISchema") not in re.sub(r"\s", "", data)
     assert (
-        'classTestUISchema(ma.Schema):"""TestUISchemaschema."""a=ma_fields.Nested(lambda:B())'
+        'classTestUISchema(ma.Schema):"""TestUISchemaschema."""a=ma_fields.Nested(lambda:BUISchema())'
         in re.sub(r"\s", "", data)
     )
 
@@ -287,9 +281,9 @@ def test_generate_nested_schema_array(fulltext_builder):
         os.path.join("test", "services", "records", "ui_schema.py")
     ) as f:
         data = f.read()
-    assert B_SCHEMA in re.sub(r"\s", "", data)
+    assert BUI_SCHEMA in re.sub(r"\s", "", data)
     assert (
-        'classTestUISchema(ma.Schema):"""TestUISchemaschema."""a=ma_fields.List(ma_fields.Nested(lambda:B()))'
+        'classTestUISchema(ma.Schema):"""TestUISchemaschema."""a=ma_fields.List(ma_fields.Nested(lambda:BUISchema()))'
         in re.sub(r"\s", "", data)
     )
 
@@ -349,18 +343,13 @@ def test_generate_nested_schema_relative_same_package(fulltext_builder):
             """class TestUISchema(ma.Schema):
         \"""TestUISchema schema.\"""
     
-        a = ma_fields.Nested(lambda:B())""",
+        a = ma_fields.Nested(lambda:BUISchema())""",
         )
         in re.sub(r"\s", "", data)
     )
 
-    assert "from test.services.records.schema2 import B" in data
-
-    with fulltext_builder.filesystem.open(
-        os.path.join("test", "services", "records", "schema2.py")  # NOSONAR
-    ) as f:
-        data = f.read()
-    assert B_SCHEMA in re.sub(r"\s", "", data)
+    assert "from test.services.records.schema2 import BUISchema" not in data
+    assert BUI_SCHEMA in re.sub(r"\s", "", data)
 
 
 def test_generate_nested_schema_relative_same_file(fulltext_builder):
@@ -393,7 +382,7 @@ def test_generate_nested_schema_relative_same_file(fulltext_builder):
             """class TestUISchema(ma.Schema):
         \"""TestUISchema schema.\"""
 
-        a = ma_fields.Nested(lambda:B())""",
+        a = ma_fields.Nested(lambda:BUISchema())""",
         )
         in re.sub(r"\s", "", data)
     )
@@ -429,18 +418,13 @@ def test_generate_nested_schema_relative_upper(fulltext_builder):
             """class TestUISchema(ma.Schema):
         \"""TestUISchema schema.\"""
 
-        a = ma_fields.Nested(lambda: B())""",
+        a = ma_fields.Nested(lambda: BUISchema())""",
         )
         in re.sub(r"\s", "", data)
     )
 
-    assert "from test.services.schema2 import B" in data
-
-    with fulltext_builder.filesystem.open(
-        os.path.join("test", "services", "schema2.py")  # NOSONAR
-    ) as f:
-        data = f.read()
-    assert B_SCHEMA in re.sub(r"\s", "", data)
+    assert "from test.services.schema2 import BUISchema" not in data
+    assert BUI_SCHEMA in re.sub(r"\s", "", data)
 
 
 def test_generate_json_serializer(fulltext_builder):


### PR DESCRIPTION
for classes with the same signature - we do not want to fix sources because this brings a lot of problems with circular imports