### PR TITLE
Trappl/be 491 model builder oai section component

### DIFF
--- a/oarepo_model_builder/builtin_models/oaipmh.json
+++ b/oarepo_model_builder/builtin_models/oaipmh.json
@@ -1,0 +1,9 @@
+{
+    "service-config": {
+      "extend:components": [
+        "{{oarepo_oaipmh_harvester.components.OaiSectionComponent}}"
+      ]
+    }
+  }
+  
+  

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-model-builder
-version = 4.0.92
+version = 4.0.93
 description = A utility library that generates OARepo required data model files from a JSON specification file
 authors = Miroslav Bauer <bauer@cesnet.cz>, Miroslav Simek <simeki@vscht.cz>
 readme = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ oarepo_model_builder.datatypes.components =
 oarepo.models =
     invenio  = oarepo_model_builder.builtin_models:invenio.json
     doi  = oarepo_model_builder.builtin_models:doi.json
+    oaipmh = oarepo_model_builder.builtin_models:oaipmh.json
 
 # outputs are generic, profile independent
 oarepo_model_builder.outputs =

--- a/tests/test_include_components.py
+++ b/tests/test_include_components.py
@@ -18,7 +18,7 @@ def test_include_invenio():
 
             "record": {
                 "module": {"qualified": "test"},
-                OAREPO_USE: ["invenio", "doi"],
+                OAREPO_USE: ["invenio", "doi", "oaipmh"],
                 "properties": {"a": {"type": "keyword", "required": True}},
             },
         },
@@ -36,4 +36,4 @@ def test_include_invenio():
         os.path.join("test", "services", "records", "config.py")
     ).read()
     data = str(data)
-    assert "components=[*PermissionsPresetsConfigMixin.components,*InvenioRecordServiceConfig.components,DoiComponent]" in re.sub(r"\s", "", data)
+    assert "components=[*PermissionsPresetsConfigMixin.components,*InvenioRecordServiceConfig.components,DoiComponent,OaiSectionComponent]" in re.sub(r"\s", "", data)


### PR DESCRIPTION
- due to some changes in components removed, oai section in records harvested is missing
    - this issue adds back the section